### PR TITLE
Fix sslify

### DIFF
--- a/lib/POE/Component/Client/HTTP.pm
+++ b/lib/POE/Component/Client/HTTP.pm
@@ -342,7 +342,15 @@ sub _poco_weeble_connect_done {
 
     $request->[REQ_CONNECTION] = $connection;
 
-    my $peer_addr = getpeername($new_wheel->get_input_handle());
+    # SSLify needs us to call it's function to get the "real" socket
+    my $peer_addr;
+    if ( $request->scheme eq 'http' ) {
+      $peer_addr = getpeername($new_wheel->get_input_handle());
+    } else {
+      my $socket = $new_wheel->get_input_handle();
+      $peer_addr = getpeername(POE::Component::SSLify::SSLify_GetSocket($socket));
+    }
+
     if (defined $peer_addr) {
       # TODO - Kludge.  How to identify IP address family?
       if (length($peer_addr) == 16) {

--- a/t/01_ssl.t
+++ b/t/01_ssl.t
@@ -13,6 +13,10 @@ unless (grep /SSLify/, keys %INC) {
   plan skip_all => 'Need POE::Component::SSLify to test SSL';
 }
 
+if ( $^O eq 'MSWin32' ) {
+  plan skip_all => 'POE::Component::SSLify does not work on MSWin32. Please help the author if you can fix this!';
+}
+
 plan tests => 1;
 
 $| = 1;


### PR DESCRIPTION
This includes 2 commits to fix the RT tickets. Unfortunately, SSLify doesn't work on win32 _yet_ and the best course of action is to simply skip the test on this platform.
