### PR TITLE
Change URL in SSL test to google

### DIFF
--- a/t/01_ssl.t
+++ b/t/01_ssl.t
@@ -27,7 +27,7 @@ sub client_start {
   DEBUG and warn "client starting...\n";
 
   my $secure_request = GET(
-    'https://thirdlobe.com/',
+    'https://www.google.com/',
     Connection => 'close',
   );
   $kernel->post(


### PR DESCRIPTION
The thirdlobe site uses a self-signed certificate.

This isn't a problem with SSLify as it doesn't do certificate verification.

When I ultimately release TLSify is does do certificate verification, so this test will fail when I provide the patches to use that module instead.